### PR TITLE
[Bug fix] added mutex lock to log output

### DIFF
--- a/src/Flexbar.h
+++ b/src/Flexbar.h
@@ -15,6 +15,7 @@
 #include <tbb/pipeline.h>
 #include <tbb/task_scheduler_init.h>
 #include <tbb/concurrent_vector.h>
+#include <tbb/mutex.h>
 
 #include <seqan/basic.h>
 #include <seqan/sequence.h>

--- a/src/SeqAlign.h
+++ b/src/SeqAlign.h
@@ -3,6 +3,7 @@
 #ifndef FLEXBAR_SEQALIGN_H
 #define FLEXBAR_SEQALIGN_H
 
+tbb::mutex ouputMutex;
 
 template <typename TSeqStr, typename TString, class TAlgorithm>
 class SeqAlign {
@@ -305,7 +306,9 @@ public:
 			  << "read seq  " << seqRead.seq << "\n\n" << endl;
 		}
 		
+		ouputMutex.lock();
 		*m_out << s.str();
+		ouputMutex.unlock();
 		
 		return ++qIndex;
 	}


### PR DESCRIPTION
While writing the log file with multiple threads they interfere with each other. Example snippet (manually marked newlines):
03574061-09b5-457e-8393-834662425f85_end2_Flexbar_removal_cmdline revcomp       cmdline revcomp 33      55      22      0       0       3.3 [[newline]]
73      22      0       1       3.3 [[newline]]
8152af77-21ac-42be-8f4a-4312a83dd68d_end2_Flexbar_removal_cmdline revcomp       cmd9d69c09c-dcbf-4f71-88c4-641425875fc4_end2_Flexbar_removal_cmdline revcomp    cmdline revcomp 37      59      22      0       0       3.3 [[newline]]
8bbe7d99-60c7-4a34-9f09-532a97cba751_end1_Flexbar_removal_cmdline       cmdline 17      39      22      0       1       3.3 [[newline]]

